### PR TITLE
Existing UserAgent test will always pass / user agent sniffing for iOS 8 issues

### DIFF
--- a/src/fixedfixed.js
+++ b/src/fixedfixed.js
@@ -58,7 +58,7 @@
 		docEl.className += " " + htmlclass;
 	}
 	
-	if (!failedFromUA && !succeedFromUA) {
+	if (!failedFromUA && !succeededFromUA) {
 		// do the test
 		
 		// bind to scroll event so we can test and potentially degrade

--- a/src/fixedfixed.js
+++ b/src/fixedfixed.js
@@ -53,12 +53,12 @@
 		(ua.match(/iPad|iPhone|iPod/) && !window.MSStream);
 		
 	// if a particular UA is known to return false results with this feature test, try and avoid that UA here.
-	if(!failFromUA){
+	if(!failedFromUA){
 		//add the HTML class for now.
 		docEl.className += " " + htmlclass;
 	}
 	
-	if (!failFromUA && !succeedFromUA) {
+	if (!failedFromUA && !succeedFromUA) {
 		// do the test
 		
 		// bind to scroll event so we can test and potentially degrade

--- a/src/fixedfixed.js
+++ b/src/fixedfixed.js
@@ -40,13 +40,13 @@
 
 	var failedFromUA = 
 		// Android 2.1, 2.2, 2.5, and 2.6 Webkit
-		!( ua.match( /Android 2\.[1256]/ ) && ua.indexOf( "AppleWebKit") > -1 ) ||
+		( ua.match( /Android 2\.[1256]/ ) && ua.indexOf( "AppleWebKit") > -1 ) ||
 		// Opera Mobile less than version 11.0 (7458)
-		!( ua.match( /Opera Mobi\/([0-9]+)/ ) && RegExp.$1 < 7458 ) ||
+		( ua.match( /Opera Mobi\/([0-9]+)/ ) && RegExp.$1 < 7458 ) ||
 		// Opera Mini
-		!( w.operamini && ({}).toString.call( w.operamini ) === "[object OperaMini]" ) ||
+		( w.operamini && ({}).toString.call( w.operamini ) === "[object OperaMini]" ) ||
 		// Firefox Mobile less than version 6
-		!( ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 < 6 );
+		( ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 < 6 );
 	
 	var succeededFromUA =
 		// iOS fails the feature test

--- a/src/fixedfixed.js
+++ b/src/fixedfixed.js
@@ -38,8 +38,7 @@
 		}
 	}
 
-	// if a particular UA is known to return false results with this feature test, try and avoid that UA here.
-	if(
+	var failedFromUA = 
 		// Android 2.1, 2.2, 2.5, and 2.6 Webkit
 		!( ua.match( /Android 2\.[1256]/ ) && ua.indexOf( "AppleWebKit") > -1 ) ||
 		// Opera Mobile less than version 11.0 (7458)
@@ -47,12 +46,21 @@
 		// Opera Mini
 		!( w.operamini && ({}).toString.call( w.operamini ) === "[object OperaMini]" ) ||
 		// Firefox Mobile less than version 6
-		!( ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 < 6 )
-		// If necessary, add the other untestable browsers here...
-	){
+		!( ua.match( /Fennec\/([0-9]+)/ ) && RegExp.$1 < 6 );
+	
+	var succeededFromUA =
+		// iOS fails the feature test
+		(ua.match(/iPad|iPhone|iPod/) && !window.MSStream);
+		
+	// if a particular UA is known to return false results with this feature test, try and avoid that UA here.
+	if(!failFromUA){
 		//add the HTML class for now.
 		docEl.className += " " + htmlclass;
-
+	}
+	
+	if (!failFromUA && !succeedFromUA) {
+		// do the test
+		
 		// bind to scroll event so we can test and potentially degrade
 		if( w.addEventListener ){
 			w.addEventListener( "scroll", checkFixed, false );


### PR DESCRIPTION
I believe that there is a giant bug i the big IF in fixedfixed.js. Basically that each item in the condition should be anded together. 

I noticed this while addressing an issue in iOS 8 that makes it always fail the scroll test, requiring a userAgent test to avoid.
